### PR TITLE
Support for preventable cave-ins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
-/*.iml
+*.iml
+*.ipr
+*.iws
 /.gradle/
 /build*/
 /doc*/

--- a/src/main/scala/repose/block/FallingBlockExtensions.scala
+++ b/src/main/scala/repose/block/FallingBlockExtensions.scala
@@ -112,8 +112,11 @@ object FallingBlockExtensions {
 
         def canSpreadInAvalanche = !EnviroMineLoaded && canSpread && avalanches && !block.isSoil
 
+        def hasValidSupport(xyz: XYZ)(implicit w: World) =
+            xyz.neighbors.count(neighbour => !canDisplace(blockAt(neighbour)) && !canDisplace(blockBelow(neighbour))) >= minSupportBlocks
+
         def canFallFrom(xyz: XYZ)(implicit w: World) =
-            canFall && !w.isRemote && canDisplace(blockBelow(xyz))
+            canFall && !w.isRemote && canDisplace(blockBelow(xyz)) && !hasValidSupport(xyz)
 
         def fallFrom(xyz: XYZ, xyzOrigin: XYZ)(implicit w: World) {
             if(!blocksFallInstantlyAt(xyz)) {
@@ -134,7 +137,7 @@ object FallingBlockExtensions {
         }
 
         def canSpreadFrom(xyz: XYZ)(implicit w: World) =
-            canSpread && !w.isRemote && !populating && !canDisplace(blockBelow(xyz))
+            canSpread && !w.isRemote && !populating && !canDisplace(blockBelow(xyz)) && !hasValidSupport(xyz)
 
         def spreadFrom(xyz: XYZ)(implicit w: World) {
             val freeNeighbors = xyz.neighbors.filter(canSpreadThrough)

--- a/src/main/scala/repose/block/FallingBlockExtensions.scala
+++ b/src/main/scala/repose/block/FallingBlockExtensions.scala
@@ -89,6 +89,8 @@ object FallingBlockExtensions {
 
     def canDisplace(block: Block) = !block.isSolid
 
+    def isSticky(block: Block) = block.isDirt || block.isSoil || block.isClay
+
     def copyTileEntityTags(xyz: XYZ, tags: NBTTagCompound)(implicit w: World) {
         tileEntityOptionAt(xyz).foreach { tileEntity =>
             val newTags = new NBTTagCompound
@@ -112,11 +114,14 @@ object FallingBlockExtensions {
 
         def canSpreadInAvalanche = !EnviroMineLoaded && canSpread && avalanches && !block.isSoil
 
-        def hasValidSupport(xyz: XYZ)(implicit w: World) =
-            xyz.neighbors.count(neighbour => !canDisplace(blockAt(neighbour)) && !canDisplace(blockBelow(neighbour))) >= minSupportBlocks
+        def hasValidSupportAt(xyz: XYZ)(implicit w: World) =
+            isSticky(blockAt(xyz)) &&
+              xyz.neighbors.count(
+                  neighbour => !canDisplace(blockAt(neighbour)) && !canDisplace(blockBelow(neighbour))
+              ) >= minSupportBlocks
 
         def canFallFrom(xyz: XYZ)(implicit w: World) =
-            canFall && !w.isRemote && canDisplace(blockBelow(xyz)) && !hasValidSupport(xyz)
+            canFall && !w.isRemote && canDisplace(blockBelow(xyz)) && !hasValidSupportAt(xyz)
 
         def fallFrom(xyz: XYZ, xyzOrigin: XYZ)(implicit w: World) {
             if(!blocksFallInstantlyAt(xyz)) {
@@ -137,7 +142,7 @@ object FallingBlockExtensions {
         }
 
         def canSpreadFrom(xyz: XYZ)(implicit w: World) =
-            canSpread && !w.isRemote && !populating && !canDisplace(blockBelow(xyz)) && !hasValidSupport(xyz)
+            canSpread && !w.isRemote && !populating && !canDisplace(blockBelow(xyz)) && !hasValidSupportAt(xyz)
 
         def spreadFrom(xyz: XYZ)(implicit w: World) {
             val freeNeighbors = xyz.neighbors.filter(canSpreadThrough)

--- a/src/main/scala/repose/config/ReposeConfig.scala
+++ b/src/main/scala/repose/config/ReposeConfig.scala
@@ -30,7 +30,7 @@ object ReposeConfig extends ConfigCategory(None, ReposeMod.name) {
     val minSupportBlocks = new NumericSetting(this, "Minimum Support Blocks",
         s"Some blocks can avoid cave-ins by having this many stable blocks beside them. A block is considered stable" +
         s"if it and the block below it cannot fall. Set to 5 to disable this and make all blocks fall regardless.",
-        5, 1, 4, 1)
+        5, 1, 5, 1)
 }
 
 /** Allowed values for [[ReposeConfig]] [[MultiChoiceSetting]]s.

--- a/src/main/scala/repose/config/ReposeConfig.scala
+++ b/src/main/scala/repose/config/ReposeConfig.scala
@@ -28,9 +28,9 @@ object ReposeConfig extends ConfigCategory(None, ReposeMod.name) {
         s"Note: this option has no effect when using the EnviroMine mod.", true)
 
     val minSupportBlocks = new NumericSetting(this, "Minimum Support Blocks",
-        s"Need at least this many stable blocks beside a block to prevent cave-in. A neighbour block is considered " +
-        s"stable if it and the block below it cannot fall. Set to 4 to disable this (blocks with no support directly " +
-        s"beneath them will fall).", 4, 1, 4, 1)
+        s"Some blocks can avoid cave-ins by having this many stable blocks beside them. A block is considered stable" +
+        s"if it and the block below it cannot fall. Set to 5 to disable this and make all blocks fall regardless.",
+        5, 1, 4, 1)
 }
 
 /** Allowed values for [[ReposeConfig]] [[MultiChoiceSetting]]s.

--- a/src/main/scala/repose/config/ReposeConfig.scala
+++ b/src/main/scala/repose/config/ReposeConfig.scala
@@ -26,6 +26,11 @@ object ReposeConfig extends ConfigCategory(None, ReposeMod.name) {
     val avalanches = new BooleanSetting(this, "Avalanches",
         s"If true, non-soil blocks that can spread will also trigger avalanches when disturbed. " +
         s"Note: this option has no effect when using the EnviroMine mod.", true)
+
+    val minSupportBlocks = new NumericSetting(this, "Minimum Support Blocks",
+        s"Need at least this many stable blocks beside a block to prevent cave-in. A neighbour block is considered " +
+        s"stable if it and the block below it cannot fall. Set to 4 to disable this (blocks with no support directly " +
+        s"beneath them will fall).", 4, 1, 4, 1)
 }
 
 /** Allowed values for [[ReposeConfig]] [[MultiChoiceSetting]]s.


### PR DESCRIPTION
Added extra rules for neighbor blocks that can prevent cave-in of dirt and other sticky material in certain conditions. Lets me carefully replace the ceiling of my dirt-covered stone cave without destroying the terrain above it.
